### PR TITLE
add tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ ENV GOPATH=/go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -a -ldflags "-s -w" -o /go/bin/upyun-exporter .
 
 FROM library/alpine:3.15.0
+RUN apk --no-cache add tzdata
 COPY --from=build-env /go/bin/upyun-exporter /usr/bin/upyun-exporter
 ENTRYPOINT ["upyun-exporter"]


### PR DESCRIPTION
在 https://github.com/douban/upyun-exporter/pull/5 添加时区转换后，使用Time.In(timeZone)出现报错，本地正常，查询是容器内缺少包，因此在镜像中增加 tzdata
```
$ klog upyun-exporter-9cfb56cd8-7h6v5
2022/10/10 07:27:19 0.0.0.0:9300
2022/10/10 07:27:19 Running on 0.0.0.0:9300
panic: time: missing Location in call to Time.In

goroutine 100 [running]:
time.Time.In(...)
        /usr/local/go/src/time/time.go:1122
upyun-test/httpRequest.DoHttpBandWidthRequest({0xc000034498, 0x11}, {0xc00003003c, 0x24}, 0x708, 0x12c)
        /go/src/github.com/douban/upyun-exporter/httpRequest/httpRequest.go:106 +0x94b
upyun-test/exporter.(*cdnExporter).Collect(0xc0002aa380, 0xc0004f4f60?)
        /go/src/github.com/douban/upyun-exporter/exporter/exporter.go:165 +0xc5
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /go/pkg/mod/github.com/prometheus/client_golang@v1.13.0/prometheus/registry.go:453 +0x10d
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
        /go/pkg/mod/github.com/prometheus/client_golang@v1.13.0/prometheus/registry.go:464 +0x55d
```