### PR TITLE
Fix upyun 403 as not hit err

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -201,7 +201,7 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 			)
 
 			for _, point := range cdnFlowDetailData {
-				// FIXME: upyun treats 403 as not hitted
+				// FIXME: upyun treats 403 as not hit
 				cdnHitRateTotal = cdnHitRateTotal + (float64(point.Hit) + float64(point.Code403)) / float64(point.Reqs)
 				cdnFlowHitRateTotal = cdnFlowHitRateTotal + (float64(point.HitBytes) / float64(point.Bytes))
 				code200Total += point.Code200

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -201,7 +201,8 @@ func (e *CdnExporter) Collect(ch chan<- prometheus.Metric) {
 			)
 
 			for _, point := range cdnFlowDetailData {
-				cdnHitRateTotal = cdnHitRateTotal + (float64(point.Hit) / float64(point.Reqs))
+				// FIXME: upyun treats 403 as not hitted
+				cdnHitRateTotal = cdnHitRateTotal + (float64(point.Hit) + float64(point.Code403)) / float64(point.Reqs)
 				cdnFlowHitRateTotal = cdnFlowHitRateTotal + (float64(point.HitBytes) / float64(point.Bytes))
 				code200Total += point.Code200
 				code206Total += point.Code206


### PR DESCRIPTION
upyun现在把403算成未命中,会影响命中率的计算. 403应该是预期之中的,所以这里把403加上了. 如果哪天upyun改了再revert吧.